### PR TITLE
BG 16x16pxタイルモードでのVRAMタイルデータアドレスを修正

### DIFF
--- a/rtl/console/ppu/bg.sv
+++ b/rtl/console/ppu/bg.sv
@@ -120,13 +120,14 @@ module bg
     always_comb begin
         case (mode)
             3'b001: vram_data_addr = tile_big // 2bpp
-                        ? ({data_base, 12'h0} + {tile_index, fine_y, xeff[3]})
-                        : ({data_base, 12'h0} + {2'h0, tile_index, fine_y[2:0]}); 
+                        ? ({data_base, 12'h0} + {tile_index + {5'h0, fine_y[3], 3'h0, xeff[3]}, fine_y[2:0]})
+                                // tile_index + (10h: 下) + (1: 右)
+                        : ({data_base, 12'h0} + {tile_index, fine_y[2:0]});
             3'b010: vram_data_addr = tile_big // 4bpp
-                        ? ({data_base, 12'h0} + {tile_index[8:0], fetch_data_num[1], fine_y, xeff[3]})
-                        : ({data_base, 12'h0} + {1'b0, tile_index, fetch_data_num[1], fine_y[2:0]});
+                        ? ({data_base, 12'h0} + {tile_index + {5'h0, fine_y[3], 3'h0, xeff[3]}, fetch_data_num[1], fine_y[2:0]})
+                        : ({data_base, 12'h0} + {tile_index, fetch_data_num[1], fine_y[2:0]});
             3'b011: vram_data_addr = tile_big // 8bpp
-                        ? ({data_base, 12'h0} + {tile_index[7:0], fetch_data_num[2:1], fine_y, xeff[3]})
+                        ? ({data_base, 12'h0} + {tile_index + {5'h0, fine_y[3], 3'h0, xeff[3]}, fetch_data_num[2:1], fine_y[2:0]})
                         : ({data_base, 12'h0} + {tile_index, fetch_data_num[2:1], fine_y[2:0]});
             3'b101: vram_data_addr =
                         ({data_base, 12'h0} + {1'b0, tile_index, fine_y[2:0], fetch_data_num[0]}); // 2bpp H-RES


### PR DESCRIPTION
fine_y[3] * 10h + xeff[3] をtile_indexに足すのが正しい

パワプロのロゴ画面が直った
Closes #14 

![IMG_20240803_025026.jpg](https://github.com/user-attachments/assets/0aaacf60-ccb5-4b8e-97c5-338104e14c6d)

![IMG_20240803_025029_1.jpg](https://github.com/user-attachments/assets/63c3b4b8-43df-4fbc-bb51-215b41bb041d)

