### PR TITLE
ObjがVRAMアクセス中のCPUからのVRAM書き込みを無効化

### DIFF
--- a/rtl/console/ppu.sv
+++ b/rtl/console/ppu.sv
@@ -258,7 +258,11 @@ module ppu
         .address(vram_l_addr),
         .clock(clk),
         .data(wdata),
-        .wren(((~(fetch_map | fetch_data)) | fblank) & cpu_en & (b_op == B_VMDATAL)),
+        .wren(
+            ((~(fetch_map | fetch_data | ((bgmode == 3'h7) & bg7_period) | obj_vram_read)) | fblank)
+            & cpu_en
+            & (b_op == B_VMDATAL)
+        ),
         .q(vram_rdata_l)
     );
 
@@ -266,7 +270,11 @@ module ppu
         .address(vram_h_addr),
         .clock(clk),
         .data(wdata),
-        .wren(((~(fetch_map | fetch_data)) | fblank) & cpu_en & (b_op == B_VMDATAH)),
+        .wren(
+            ((~(fetch_map | fetch_data | ((bgmode == 3'h7) & bg7_period) | obj_vram_read)) | fblank)
+            & cpu_en
+            & (b_op == B_VMDATAH)
+        ),
         .q(vram_rdata_h)
     );
 


### PR DESCRIPTION
描画中（bgからのVRAMアクセス時）のVRAM書き込みは無効化していたが，ObjからのVRAMアクセス時は無効にしていなかった

#15 の問題を解決（Closes #15）
なぜか非Vblank時に00hを書き込む処理をしており，ObjからのVRAMアドレスに00hが書き込まれる結果となっていたため，タイトルの円に乱れが生じていた